### PR TITLE
mouse pad not working.

### DIFF
--- a/src/scripts/controllers.js
+++ b/src/scripts/controllers.js
@@ -766,7 +766,7 @@ adb.controller('controller', ['$scope', '$q', 'socketService', '$sce', function 
 
     $scope.mouseMoveLog = 'coord: (' + x + ', ' + y + ')';
 
-    if ($scope.coords === null) {
+    if (!$scope.coords) {
       $scope.coords = [];
     }
 


### PR DESCRIPTION
when I try to control my nexus 5 with chromeadb, it's not working with an error.
